### PR TITLE
Replace video recording raw files output with a pipe to any cmd (e.g.…

### DIFF
--- a/code/client/cl_scrn.c
+++ b/code/client/cl_scrn.c
@@ -30,6 +30,7 @@ cvar_t		*cl_debuggraph;
 cvar_t		*cl_graphheight;
 cvar_t		*cl_graphscale;
 cvar_t		*cl_graphshift;
+cvar_t		*cl_showrecordingprogress;
 
 /*
 ================
@@ -340,6 +341,9 @@ void SCR_DrawDemoRecording( void ) {
 		return;
 	}
 
+	if(!cl_showrecordingprogress->integer)
+		return;
+
 	pos = FS_FTell( clc.demofile );
 	sprintf( string, "RECORDING %s: %ik", clc.demoName, pos / 1024 );
 
@@ -458,6 +462,7 @@ void SCR_Init( void ) {
 	cl_graphheight = Cvar_Get ("graphheight", "32", CVAR_CHEAT);
 	cl_graphscale = Cvar_Get ("graphscale", "1", CVAR_CHEAT);
 	cl_graphshift = Cvar_Get ("graphshift", "0", CVAR_CHEAT);
+	cl_showrecordingprogress = Cvar_Get ("video_showrecordingprogress", "0", CVAR_ARCHIVE);
 
 	scr_initialized = qtrue;
 }

--- a/code/qcommon/qcommon.h
+++ b/code/qcommon/qcommon.h
@@ -732,6 +732,11 @@ qboolean FS_ComparePaks( char *neededpaks, int len, qboolean dlstring );
 
 void FS_Rename( const char *from, const char *to );
 
+
+fileHandle_t FS_PipeOpen(const char *qcmd, const char *qpath, const char *mode);
+void FS_PipeClose(fileHandle_t f);
+int FS_PipeWrite(const void *buffer, int len, fileHandle_t f);
+
 void FS_Remove( const char *osPath );
 void FS_HomeRemove( const char *homePath );
 


### PR DESCRIPTION
… ffmpeg)

Original code by entdark/q3mme

---

## Usage with ffmpeg

- Create `<fs_gamedir>/videos` folder, ensure write permission for your user running ioquake3.
- Put `ffmpeg/ffmpeg.exe` binary in `<fs_homepath>/` (tested with `3.2.2-x64-static`)

Windows users: `C:\Users\YOU\AppData\Roaming\Quake3`

- Add in your `autoexec.cfg` your favorite ffmpeg cmd as follow:

```
seta video_pipeCommand "ffmpeg -f avi -i - -threads 0 -preset veryfast -y -pix_fmt yuv444p -crf 19 %o.mp4 2> ffmpeglog.txt"
```

- For a 50fps capture:

```
seta cl_aviFrameRate "50"
```

**Note**:  `cl_aviFrameRate` must be a divisor of the audio rate (def: 22050) for correct audio sync.

- Record a demo (console: `\record mydemo`)

- Play the demo (console: `\demo mydemo`, or use Demos menu)

- Start the capture (console: `\video mydemo`)

- The ffmpeg subprocess will pop up and the game will lose focus if you are running in fullscreen, so just return to the game to continue the capture and close the console.

- Your video is in `<fs_gamedir>/videos/mydemo.avi.mp4` 


## Performance

`0.7x` realtime for a `1920x1080@50fps, x264 preset=veryfast crf=19` capture on a `i7-4770k/16GB`.
